### PR TITLE
Update Homebrew formula

### DIFF
--- a/homebrew/chruby-default-gems.rb
+++ b/homebrew/chruby-default-gems.rb
@@ -8,14 +8,6 @@ class ChrubyDefaultGems < Formula
 
   head 'https://github.com/tubbo/chruby-default-gems.git'
 
-  def install
-    %w(ruby jruby rubinius).each do |rb|
-      system "mkdir -p ~/.post-install.d/#{rb}"
-      system "touch ~/.post-install.d/#{rb}/default-gems"
-    end
-    system 'mkdir -p ~/.post-install.d/ruby ~/.post-install.d/jruby ~/.post-install.d/rubinius'
-  end
-
   def caveats
     %(
       Installation:

--- a/homebrew/chruby-default-gems.rb
+++ b/homebrew/chruby-default-gems.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class ChrubyDefaultGems < Formula
   homepage 'https://github.com/tubbo/chruby-default-gems#readme'
-  url 'https://github.com/tubbo/chruby-default-gems/archive/v1.0.1.tar.gz'
+  url 'https://github.com/tubbo/chruby-default-gems/archive/master.zip'
   sha1 '5e3044119248f3150d5faf3bbbf7bf48adfb2177'
 
   head 'https://github.com/tubbo/chruby-default-gems.git'

--- a/homebrew/chruby-default-gems.rb
+++ b/homebrew/chruby-default-gems.rb
@@ -3,7 +3,7 @@ require 'formula'
 class ChrubyDefaultGems < Formula
   homepage 'https://github.com/tubbo/chruby-default-gems#readme'
   url 'https://github.com/tubbo/chruby-default-gems/archive/master.zip'
-  sha1 '5e3044119248f3150d5faf3bbbf7bf48adfb2177'
+  sha1 '9abfb6f906825229b7519f3a99fa749e6939f660'
   version '0.0.1'
 
   head 'https://github.com/tubbo/chruby-default-gems.git'

--- a/homebrew/chruby-default-gems.rb
+++ b/homebrew/chruby-default-gems.rb
@@ -4,6 +4,7 @@ class ChrubyDefaultGems < Formula
   homepage 'https://github.com/tubbo/chruby-default-gems#readme'
   url 'https://github.com/tubbo/chruby-default-gems/archive/master.zip'
   sha1 '5e3044119248f3150d5faf3bbbf7bf48adfb2177'
+  version '0.0.1'
 
   head 'https://github.com/tubbo/chruby-default-gems.git'
 

--- a/homebrew/chruby-default-gems.rb
+++ b/homebrew/chruby-default-gems.rb
@@ -4,9 +4,13 @@ class ChrubyDefaultGems < Formula
   homepage 'https://github.com/tubbo/chruby-default-gems#readme'
   url 'https://github.com/tubbo/chruby-default-gems/archive/master.zip'
   sha1 '9abfb6f906825229b7519f3a99fa749e6939f660'
-  version '0.0.1'
+  version '0.0.1' # delete this line once Homebrew can detect the version from t
 
   head 'https://github.com/tubbo/chruby-default-gems.git'
+
+  def install
+    FileUtils.cp "lib/chruby/default_gems.sh", "#{prefix}/default_gems.sh"
+  end
 
   def caveats
     %(
@@ -14,7 +18,7 @@ class ChrubyDefaultGems < Formula
 
       Copy the following line into your .bash_profile or .zshenv:
 
-        source #{prefix}/lib/chruby-default-gems/lib/chruby/default_gems.sh
+        source #{prefix}/default_gems.sh
 
       You can also set the DEFAULT_GEMFILE variable if you wish to store
       your default-gems in a location other than


### PR DESCRIPTION
The Homebrew formula references a file that doesn't exist: https://github.com/tubbo/chruby-default-gems/archive/v1.0.1.tar.gz

These changes fix that.  This invocation works:

```
$ brew install https://raw.github.com/bronson/chruby-default-gems/patch-1/homebrew/chruby-default-gems.rb
```
